### PR TITLE
Add task search and filtering

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Example configuration for the CSM Dashboard
+# Currently unused. Add environment variables here if you extend the app
+# with external integrations. Not required when using localStorage only.

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Ignore user-specific configuration
+config.js
+.env
+

--- a/BUILD_PLAN.md
+++ b/BUILD_PLAN.md
@@ -1,0 +1,32 @@
+# Build Plan for CSM Dashboard
+
+This document outlines the steps to implement a simple web-based CSM dashboard using the browser's local storage as the data store.
+
+## Goals
+- Provide a responsive interface for viewing and updating customer tasks
+- Track OKRs: risk mitigation, upsell/cross-sell, success stories, and EBC/QBRs
+- Persist data locally using `localStorage`
+
+## Milestones
+1. **Project Setup**
+   - Create basic file structure (`index.html`, `style.css`, `app.js`)
+   - Add configuration template (`config.example.js`) for optional customization of the local storage key
+2. **Data Access Layer**
+   - Implement minimal functions in `app.js` to read/write tasks via `localStorage`
+3. **UI Layout**
+   - Build responsive layout with a sidebar for navigation and a main content area
+   - Include sections for tasks, account summaries, and OKR tracking
+4. **Task Management**
+   - Display tasks from local storage
+   - Provide a form to add new tasks with fields for type (risk, upsell, etc.) and due date
+5. **OKR Metrics**
+   - Compute simple counts from stored tasks (e.g., number of risk plans completed)
+   - Display metrics at the top of the dashboard
+6. **Polish**
+   - Apply basic styling for readability and mobile support
+   - Update README with usage and setup instructions
+7. **Search and Filters**
+   - Provide a search box to filter tasks by description
+   - Add a drop-down to filter tasks by type
+
+This plan keeps the implementation lightweight while demonstrating core functionality from the PRD.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 kb-codex-test
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,43 @@
-# kb-codex-test
+# CSM Dashboard
+
+A lightweight "central operating system" for Customer Success Managers (CSMs). The dashboard helps manage risk mitigation plans, upsell or cross-sell opportunities, customer success stories, and executive business reviews.
+
+Data persists in the browser via `localStorage`, so no external database is required. The app is built with plain HTML, CSS, and JavaScript.
+
+## Features
+- Unified list of accounts and tasks
+- OKR tracking: risk mitigation, upsell/cross-sell, success stories, and executive meetings
+- Add and update tasks directly in the dashboard
+- Search box and drop-down filters to quickly find tasks
+
+## Setup
+1. Clone this repository.
+2. (Optional) copy `config.example.js` to `config.js` to customise the local storage keys.
+3. Serve the files from a static host or run a simple local server:
+
+   ```bash
+   python3 -m http.server 8080
+   ```
+   Then open <http://localhost:8080/> in your browser.
+   Use the search box and filter drop-down in the Tasks section to narrow results.
+
+### Sample Configuration
+`config.example.js` contains the default storage keys:
+
+```javascript
+// config.js
+// Customize the keys used in localStorage
+window.STORAGE_KEY = 'csm_tasks';
+window.ACCOUNT_KEY = 'csm_accounts';
+```
+
+Rename this file to `config.js` if you need to override the default keys. An `.env.example` file is also provided for potential future integrations.
+
+## Development
+See [BUILD_PLAN.md](BUILD_PLAN.md) for the project roadmap and planned milestones.
+
+## Contributing
+Contributions are welcome! Fork the repository, create a branch for your changes, and open a pull request. Please follow conventional commit messages and update documentation when adding new features.
+
+## License
+This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Data persists in the browser via `localStorage`, so no external database is requ
 ## Features
 - Unified list of accounts and tasks
 - OKR tracking: risk mitigation, upsell/cross-sell, success stories, and executive meetings
-- Add and update tasks directly in the dashboard
+- Add, edit, and delete tasks and accounts directly in the dashboard
 - Search box and drop-down filters to quickly find tasks
 
 ## Setup

--- a/app.js
+++ b/app.js
@@ -2,6 +2,10 @@
 const STORAGE_KEY = window.STORAGE_KEY || 'csm_tasks';
 const ACCOUNT_KEY = window.ACCOUNT_KEY || 'csm_accounts';
 
+function generateId() {
+    return Date.now().toString(36) + Math.random().toString(36).slice(2);
+}
+
 function getStoredTasks() {
     try {
         const raw = localStorage.getItem(STORAGE_KEY);
@@ -41,17 +45,51 @@ function renderTasks(tasks) {
     list.innerHTML = '';
     tasks.forEach((task) => {
         const li = document.createElement('div');
-        li.className = 'list-group-item task-item';
-        li.textContent = `${task.name} (${task.type})${task.due ? ` due ${task.due}` : ''}`;
+        li.className = 'list-group-item d-flex justify-content-between align-items-center';
+        li.dataset.id = task.id;
+
+        const span = document.createElement('span');
+        span.textContent = `${task.name} (${task.type})${task.due ? ` due ${task.due}` : ''}`;
+        li.appendChild(span);
+
+        const btnGroup = document.createElement('div');
+        btnGroup.className = 'btn-group btn-group-sm';
+
+        const editBtn = document.createElement('button');
+        editBtn.className = 'btn btn-outline-secondary edit-task';
+        editBtn.innerHTML = '<i class="bi bi-pencil"></i>';
+        btnGroup.appendChild(editBtn);
+
+        const delBtn = document.createElement('button');
+        delBtn.className = 'btn btn-outline-danger delete-task';
+        delBtn.innerHTML = '<i class="bi bi-trash"></i>';
+        btnGroup.appendChild(delBtn);
+
+        li.appendChild(btnGroup);
         list.appendChild(li);
     });
 }
 
 function addTask(name, type, due) {
     const tasks = getStoredTasks();
-    tasks.push({ name, type, due });
+    tasks.push({ id: generateId(), name, type, due });
     saveTasks(tasks);
     refreshTaskList();
+}
+
+function updateTask(id, name, type, due) {
+    const tasks = getStoredTasks();
+    const idx = tasks.findIndex(t => t.id === id);
+    if (idx !== -1) {
+        tasks[idx] = { id, name, type, due };
+        saveTasks(tasks);
+    }
+}
+
+function deleteTask(id) {
+    let tasks = getStoredTasks();
+    tasks = tasks.filter(t => t.id !== id);
+    saveTasks(tasks);
 }
 
 function getStoredAccounts() {
@@ -79,22 +117,57 @@ function renderAccounts(accts) {
     list.innerHTML = '';
     accts.forEach(acc => {
         const li = document.createElement('div');
-        li.className = 'list-group-item d-flex justify-content-between';
-        li.textContent = acc.name;
+        li.className = 'list-group-item d-flex justify-content-between align-items-center';
+        li.dataset.id = acc.id;
+
+        const span = document.createElement('span');
+        span.textContent = acc.name;
+
         const badge = document.createElement('span');
         badge.className = 'badge rounded-pill ms-2 ' +
             (acc.health === 'red' ? 'bg-danger' : acc.health === 'yellow' ? 'bg-warning text-dark' : 'bg-success');
         badge.textContent = acc.health;
-        li.appendChild(badge);
+        span.appendChild(badge);
+        li.appendChild(span);
+
+        const btnGroup = document.createElement('div');
+        btnGroup.className = 'btn-group btn-group-sm';
+
+        const editBtn = document.createElement('button');
+        editBtn.className = 'btn btn-outline-secondary edit-account';
+        editBtn.innerHTML = '<i class="bi bi-pencil"></i>';
+        btnGroup.appendChild(editBtn);
+
+        const delBtn = document.createElement('button');
+        delBtn.className = 'btn btn-outline-danger delete-account';
+        delBtn.innerHTML = '<i class="bi bi-trash"></i>';
+        btnGroup.appendChild(delBtn);
+
+        li.appendChild(btnGroup);
         list.appendChild(li);
     });
 }
 
 function addAccount(name, health) {
     const accts = getStoredAccounts();
-    accts.push({ name, health });
+    accts.push({ id: generateId(), name, health });
     saveAccounts(accts);
     fetchAccounts();
+}
+
+function updateAccount(id, name, health) {
+    const accts = getStoredAccounts();
+    const idx = accts.findIndex(a => a.id === id);
+    if (idx !== -1) {
+        accts[idx] = { id, name, health };
+        saveAccounts(accts);
+    }
+}
+
+function deleteAccount(id) {
+    let accts = getStoredAccounts();
+    accts = accts.filter(a => a.id !== id);
+    saveAccounts(accts);
 }
 
 function renderOKRs(tasks) {
@@ -166,6 +239,73 @@ document.getElementById('task-search').addEventListener('input', (e) => {
 document.getElementById('task-filter').addEventListener('change', (e) => {
     filterType = e.target.value;
     refreshTaskList();
+});
+
+// Handle edit/delete actions for tasks
+document.getElementById('task-list').addEventListener('click', (e) => {
+    const id = e.target.closest('.list-group-item')?.dataset.id;
+    if (!id) return;
+    if (e.target.closest('.delete-task')) {
+        deleteTask(id);
+        refreshTaskList();
+        if (!document.getElementById('okr').classList.contains('d-none')) {
+            renderOKRs(getStoredTasks());
+        }
+    } else if (e.target.closest('.edit-task')) {
+        const tasks = getStoredTasks();
+        const t = tasks.find(tsk => tsk.id === id);
+        if (t) {
+            document.getElementById('edit-task-id').value = t.id;
+            document.getElementById('edit-task-name').value = t.name;
+            document.getElementById('edit-task-type').value = t.type;
+            document.getElementById('edit-task-due').value = t.due || '';
+            const modal = new bootstrap.Modal(document.getElementById('task-modal'));
+            modal.show();
+        }
+    }
+});
+
+document.getElementById('edit-task-form').addEventListener('submit', (e) => {
+    e.preventDefault();
+    const id = document.getElementById('edit-task-id').value;
+    const name = document.getElementById('edit-task-name').value;
+    const type = document.getElementById('edit-task-type').value;
+    const due = document.getElementById('edit-task-due').value;
+    updateTask(id, name, type, due);
+    refreshTaskList();
+    const modalElement = document.getElementById('task-modal');
+    bootstrap.Modal.getInstance(modalElement).hide();
+});
+
+// Handle edit/delete actions for accounts
+document.getElementById('account-list').addEventListener('click', (e) => {
+    const id = e.target.closest('.list-group-item')?.dataset.id;
+    if (!id) return;
+    if (e.target.closest('.delete-account')) {
+        deleteAccount(id);
+        fetchAccounts();
+    } else if (e.target.closest('.edit-account')) {
+        const accts = getStoredAccounts();
+        const acct = accts.find(a => a.id === id);
+        if (acct) {
+            document.getElementById('edit-account-id').value = acct.id;
+            document.getElementById('edit-account-name').value = acct.name;
+            document.getElementById('edit-account-health').value = acct.health;
+            const modal = new bootstrap.Modal(document.getElementById('account-modal'));
+            modal.show();
+        }
+    }
+});
+
+document.getElementById('edit-account-form').addEventListener('submit', (e) => {
+    e.preventDefault();
+    const id = document.getElementById('edit-account-id').value;
+    const name = document.getElementById('edit-account-name').value;
+    const health = document.getElementById('edit-account-health').value;
+    updateAccount(id, name, health);
+    fetchAccounts();
+    const modalElement = document.getElementById('account-modal');
+    bootstrap.Modal.getInstance(modalElement).hide();
 });
 
 // Load tasks by default

--- a/app.js
+++ b/app.js
@@ -1,0 +1,172 @@
+// Local storage keys can be customized via config.js
+const STORAGE_KEY = window.STORAGE_KEY || 'csm_tasks';
+const ACCOUNT_KEY = window.ACCOUNT_KEY || 'csm_accounts';
+
+function getStoredTasks() {
+    try {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        return raw ? JSON.parse(raw) : [];
+    } catch (err) {
+        console.error('Failed to load tasks', err);
+        return [];
+    }
+}
+
+function saveTasks(tasks) {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(tasks));
+}
+
+function fetchTasks() {
+    return getStoredTasks();
+}
+
+let searchQuery = '';
+let filterType = '';
+
+function applyTaskFilters(tasks) {
+    return tasks.filter(t => {
+        const matchesSearch = !searchQuery || t.name.toLowerCase().includes(searchQuery);
+        const matchesType = !filterType || t.type === filterType;
+        return matchesSearch && matchesType;
+    });
+}
+
+function refreshTaskList() {
+    const tasks = applyTaskFilters(getStoredTasks());
+    renderTasks(tasks);
+}
+
+function renderTasks(tasks) {
+    const list = document.getElementById('task-list');
+    list.innerHTML = '';
+    tasks.forEach((task) => {
+        const li = document.createElement('div');
+        li.className = 'list-group-item task-item';
+        li.textContent = `${task.name} (${task.type})${task.due ? ` due ${task.due}` : ''}`;
+        list.appendChild(li);
+    });
+}
+
+function addTask(name, type, due) {
+    const tasks = getStoredTasks();
+    tasks.push({ name, type, due });
+    saveTasks(tasks);
+    refreshTaskList();
+}
+
+function getStoredAccounts() {
+    try {
+        const raw = localStorage.getItem(ACCOUNT_KEY);
+        return raw ? JSON.parse(raw) : [];
+    } catch (err) {
+        console.error('Failed to load accounts', err);
+        return [];
+    }
+}
+
+function saveAccounts(accts) {
+    localStorage.setItem(ACCOUNT_KEY, JSON.stringify(accts));
+}
+
+function fetchAccounts() {
+    const accts = getStoredAccounts();
+    renderAccounts(accts);
+    return accts;
+}
+
+function renderAccounts(accts) {
+    const list = document.getElementById('account-list');
+    list.innerHTML = '';
+    accts.forEach(acc => {
+        const li = document.createElement('div');
+        li.className = 'list-group-item d-flex justify-content-between';
+        li.textContent = acc.name;
+        const badge = document.createElement('span');
+        badge.className = 'badge rounded-pill ms-2 ' +
+            (acc.health === 'red' ? 'bg-danger' : acc.health === 'yellow' ? 'bg-warning text-dark' : 'bg-success');
+        badge.textContent = acc.health;
+        li.appendChild(badge);
+        list.appendChild(li);
+    });
+}
+
+function addAccount(name, health) {
+    const accts = getStoredAccounts();
+    accts.push({ name, health });
+    saveAccounts(accts);
+    fetchAccounts();
+}
+
+function renderOKRs(tasks) {
+    const metrics = {
+        Risk: 0,
+        Upsell: 0,
+        Story: 0,
+        EBC: 0
+    };
+    tasks.forEach(t => { metrics[t.type] = (metrics[t.type] || 0) + 1; });
+    const list = document.getElementById('okr-metrics');
+    list.innerHTML = '';
+    Object.keys(metrics).forEach(key => {
+        const li = document.createElement('li');
+        li.className = 'list-group-item d-flex justify-content-between align-items-center';
+        li.textContent = key;
+        const span = document.createElement('span');
+        span.className = 'badge bg-primary rounded-pill';
+        span.textContent = metrics[key];
+        li.appendChild(span);
+        list.appendChild(li);
+    });
+}
+
+document.getElementById('nav-tasks').addEventListener('click', () => {
+    document.getElementById('dashboard').classList.remove('d-none');
+    document.getElementById('accounts').classList.add('d-none');
+    document.getElementById('okr').classList.add('d-none');
+    refreshTaskList();
+});
+
+document.getElementById('nav-accounts').addEventListener('click', () => {
+    document.getElementById('dashboard').classList.add('d-none');
+    document.getElementById('okr').classList.add('d-none');
+    document.getElementById('accounts').classList.remove('d-none');
+    fetchAccounts();
+});
+
+document.getElementById('nav-okr').addEventListener('click', () => {
+    document.getElementById('dashboard').classList.add('d-none');
+    document.getElementById('accounts').classList.add('d-none');
+    document.getElementById('okr').classList.remove('d-none');
+    const tasks = fetchTasks();
+    renderOKRs(tasks);
+});
+
+document.getElementById('task-form').addEventListener('submit', (e) => {
+    e.preventDefault();
+    const name = document.getElementById('task-name').value;
+    const type = document.getElementById('task-type').value;
+    const due = document.getElementById('task-due').value;
+    addTask(name, type, due);
+    e.target.reset();
+});
+
+document.getElementById('account-form').addEventListener('submit', (e) => {
+    e.preventDefault();
+    const name = document.getElementById('account-name').value;
+    const health = document.getElementById('account-health').value;
+    addAccount(name, health);
+    e.target.reset();
+});
+
+document.getElementById('task-search').addEventListener('input', (e) => {
+    searchQuery = e.target.value.toLowerCase();
+    refreshTaskList();
+});
+
+document.getElementById('task-filter').addEventListener('change', (e) => {
+    filterType = e.target.value;
+    refreshTaskList();
+});
+
+// Load tasks by default
+refreshTaskList();

--- a/config.example.js
+++ b/config.example.js
@@ -1,0 +1,6 @@
+/* Optional configuration for the CSM Dashboard.
+ * Rename this file to config.js to override defaults.
+ */
+// Change the local storage keys if desired
+window.STORAGE_KEY = 'csm_tasks';
+window.ACCOUNT_KEY = 'csm_accounts';

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <title>CSM Dashboard</title>
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
 </head>
 <body>
     <div class="container-fluid" id="app">
@@ -84,6 +85,77 @@
                     <h2>OKR Summary</h2>
                     <ul id="okr-metrics" class="list-group list-group-flush"></ul>
                 </section>
+
+                <!-- Edit Task Modal -->
+                <div class="modal fade" id="task-modal" tabindex="-1" aria-hidden="true">
+                    <div class="modal-dialog">
+                        <div class="modal-content">
+                            <div class="modal-header">
+                                <h5 class="modal-title">Edit Task</h5>
+                                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                            </div>
+                            <form id="edit-task-form">
+                                <div class="modal-body">
+                                    <input type="hidden" id="edit-task-id">
+                                    <div class="mb-3">
+                                        <label class="form-label">Description</label>
+                                        <input type="text" id="edit-task-name" class="form-control" required>
+                                    </div>
+                                    <div class="mb-3">
+                                        <label class="form-label">Type</label>
+                                        <select id="edit-task-type" class="form-select">
+                                            <option value="Risk">Risk Mitigation</option>
+                                            <option value="Upsell">Upsell/Cross-sell</option>
+                                            <option value="Story">Success Story</option>
+                                            <option value="EBC">EBC/QBR</option>
+                                        </select>
+                                    </div>
+                                    <div class="mb-3">
+                                        <label class="form-label">Due Date</label>
+                                        <input type="date" id="edit-task-due" class="form-control">
+                                    </div>
+                                </div>
+                                <div class="modal-footer">
+                                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                                    <button type="submit" class="btn btn-primary">Save</button>
+                                </div>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Edit Account Modal -->
+                <div class="modal fade" id="account-modal" tabindex="-1" aria-hidden="true">
+                    <div class="modal-dialog">
+                        <div class="modal-content">
+                            <div class="modal-header">
+                                <h5 class="modal-title">Edit Account</h5>
+                                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                            </div>
+                            <form id="edit-account-form">
+                                <div class="modal-body">
+                                    <input type="hidden" id="edit-account-id">
+                                    <div class="mb-3">
+                                        <label class="form-label">Account Name</label>
+                                        <input type="text" id="edit-account-name" class="form-control" required>
+                                    </div>
+                                    <div class="mb-3">
+                                        <label class="form-label">Health</label>
+                                        <select id="edit-account-health" class="form-select">
+                                            <option value="green">Healthy</option>
+                                            <option value="yellow">At Risk</option>
+                                            <option value="red">Critical</option>
+                                        </select>
+                                    </div>
+                                </div>
+                                <div class="modal-footer">
+                                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                                    <button type="submit" class="btn btn-primary">Save</button>
+                                </div>
+                            </form>
+                        </div>
+                    </div>
+                </div>
             </main>
         </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSM Dashboard</title>
+    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css">
+</head>
+<body>
+    <div class="container-fluid" id="app">
+        <header class="py-3 text-center bg-primary text-white">
+            <h1>CSM Dashboard</h1>
+        </header>
+        <div class="row flex-nowrap">
+            <nav class="col-12 col-md-3 col-xl-2 p-3 bg-light sidebar">
+                <h5>Navigation</h5>
+                <ul class="nav flex-column">
+                    <li class="nav-item"><a class="nav-link" href="#" id="nav-tasks">Tasks</a></li>
+                    <li class="nav-item"><a class="nav-link" href="#" id="nav-accounts">Accounts</a></li>
+                    <li class="nav-item"><a class="nav-link" href="#" id="nav-okr">OKRs</a></li>
+                </ul>
+            </nav>
+            <main class="col px-4 py-3" id="main-content">
+                <section id="dashboard" class="d-none">
+                    <h2>Your Tasks</h2>
+                    <div class="row g-2 mb-2">
+                        <div class="col-md-6">
+                            <input type="text" id="task-search" class="form-control" placeholder="Search tasks">
+                        </div>
+                        <div class="col-md-4">
+                            <select id="task-filter" class="form-select">
+                                <option value="">All Types</option>
+                                <option value="Risk">Risk Mitigation</option>
+                                <option value="Upsell">Upsell/Cross-sell</option>
+                                <option value="Story">Success Story</option>
+                                <option value="EBC">EBC/QBR</option>
+                            </select>
+                        </div>
+                    </div>
+                    <div id="task-list" class="list-group mb-3"></div>
+                    <h3>Add Task</h3>
+                    <form id="task-form" class="row g-2">
+                        <div class="col-md-4">
+                            <input type="text" id="task-name" class="form-control" placeholder="Task description" required>
+                        </div>
+                        <div class="col-md-3">
+                            <select id="task-type" class="form-select">
+                                <option value="Risk">Risk Mitigation</option>
+                                <option value="Upsell">Upsell/Cross-sell</option>
+                                <option value="Story">Success Story</option>
+                                <option value="EBC">EBC/QBR</option>
+                            </select>
+                        </div>
+                        <div class="col-md-3">
+                            <input type="date" id="task-due" class="form-control">
+                        </div>
+                        <div class="col-md-2">
+                            <button class="btn btn-primary w-100" type="submit">Add</button>
+                        </div>
+                    </form>
+                </section>
+                <section id="accounts" class="d-none">
+                    <h2>Accounts</h2>
+                    <div id="account-list" class="list-group mb-3"></div>
+                    <h3>Add Account</h3>
+                    <form id="account-form" class="row g-2">
+                        <div class="col-md-6">
+                            <input type="text" id="account-name" class="form-control" placeholder="Account name" required>
+                        </div>
+                        <div class="col-md-4">
+                            <select id="account-health" class="form-select">
+                                <option value="green">Healthy</option>
+                                <option value="yellow">At Risk</option>
+                                <option value="red">Critical</option>
+                            </select>
+                        </div>
+                        <div class="col-md-2">
+                            <button class="btn btn-primary w-100" type="submit">Add</button>
+                        </div>
+                    </form>
+                </section>
+                <section id="okr" class="d-none">
+                    <h2>OKR Summary</h2>
+                    <ul id="okr-metrics" class="list-group list-group-flush"></ul>
+                </section>
+            </main>
+        </div>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js"></script>
+    <!-- Optional user configuration -->
+    <script src="config.js"></script>
+    <script src="app.js"></script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,9 @@
+body {
+    font-family: Arial, sans-serif;
+}
+.sidebar {
+    min-height: 100vh;
+}
+#task-list .task-item {
+    cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- enable task search input and type filter
- refresh tasks using new filter logic
- document usage in README
- outline search milestone in build plan

## Testing
- `node --check app.js`
- `python3 -m http.server 8080` *(manually terminated)*

------
https://chatgpt.com/codex/tasks/task_b_683f13ba0750833385a4b72d74dfd0f9