### PR TITLE
Add vertical OKR rollups

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,6 +42,16 @@
                             <i class="bi bi-building me-2"></i>Accounts
                         </a>
                     </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="#" id="nav-vertical">
+                            <i class="bi bi-diagram-3 me-2"></i>Vertical
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="#" id="nav-sub-vertical">
+                            <i class="bi bi-diagram-2 me-2"></i>Sub-Vertical
+                        </a>
+                    </li>
                 </ul>
             </nav>
             
@@ -186,6 +196,22 @@
                                     </form>
                                 </div>
                             </div>
+                        </section>
+                    </div>
+                    <div class="col-12 mb-4">
+                        <section id="vertical" class="d-none">
+                            <div class="d-flex justify-content-between align-items-center mb-4">
+                                <h2 class="mb-0">Vertical Rollup</h2>
+                            </div>
+                            <div id="vertical-summary" class="list-group list-group-flush"></div>
+                        </section>
+                    </div>
+                    <div class="col-12 mb-4">
+                        <section id="sub-vertical" class="d-none">
+                            <div class="d-flex justify-content-between align-items-center mb-4">
+                                <h2 class="mb-0">Sub-Vertical Rollup</h2>
+                            </div>
+                            <div id="sub-vertical-summary" class="list-group list-group-flush"></div>
                         </section>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- add Vertical and Sub-Vertical views to navigation
- render OKR rollups grouped by vertical or sub-vertical
- sort rollup groups alphabetically
- update nav event handlers and initialization

## Testing
- `node -v`
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_b_68425b12a7ac833385efc2fd40bcc57c